### PR TITLE
chore: bump Go to 1.26.0

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.18'
+          go-version: '1.26.0'
 
       - name: Run tests
         run: go test -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/sawmills/go-ssss
 
-go 1.18
+go 1.26.0


### PR DESCRIPTION
## Summary
- Bumps `go` directive in `go.mod` to `1.26.0`
- Runs `go mod tidy` to update `go.sum`

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version bump only; main risk is CI/build breakage or new compiler/lint behavior changes under Go 1.26.0.
> 
> **Overview**
> Bumps the Go version from `1.18` to `1.26.0` by updating the `go` directive in `go.mod` and the GitHub Actions test workflow (`.github/workflows/release-please.yml`) to use the same toolchain.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e25b68913655fd682004e269c8de958b32e77dfb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded to Go 1.26.0 by updating the go directive in go.mod and the GitHub Actions workflow. Ensures builds use the latest Go features and security fixes.

- **Migration**
  - Use Go 1.26.0 locally before running builds or tests.

<sup>Written for commit e25b68913655fd682004e269c8de958b32e77dfb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

